### PR TITLE
HTML escape outputs

### DIFF
--- a/telegram-host-notification.sh
+++ b/telegram-host-notification.sh
@@ -2,6 +2,7 @@
 if [ -n "$ICINGAWEB2_URL" ]; then
     HOSTDISPLAYNAME="<a href=\"$ICINGAWEB2_URL/monitoring/host/show?host=$HOSTNAME\">$HOSTDISPLAYNAME</a>"
 fi
+HOSTOUTPUT_ESCAPED=$(echo $HOSTOUTPUT | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
 template=$(cat <<TEMPLATE
 <strong>$NOTIFICATIONTYPE</strong> - $HOSTDISPLAYNAME is $HOSTSTATE
 
@@ -9,7 +10,7 @@ Host: $HOSTALIAS
 Address: $HOSTADDRESS
 Date/Time: $LONGDATETIME
 
-<pre>$HOSTOUTPUT</pre>
+<pre>$HOSTOUTPUT_ESCAPED</pre>
 TEMPLATE
 )
 if [ -n "$NOTIFICATIONCOMMENT" ]; then

--- a/telegram-service-notification.sh
+++ b/telegram-service-notification.sh
@@ -3,13 +3,14 @@ if [ -n "$ICINGAWEB2_URL" ]; then
     HOSTDISPLAYNAME="<a href=\"$ICINGAWEB2_URL/monitoring/host/show?host=$HOSTNAME\">$HOSTDISPLAYNAME</a>"
     SERVICEDISPLAYNAME="<a href=\"$ICINGAWEB2_URL/monitoring/service/show?host=$HOSTNAME&service=$SERVICEDESC\">$SERVICEDISPLAYNAME</a>"
 fi
+SERVICEOUTPUT_ESCAPED=$(echo $SERVICEOUTPUT | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
 template=$(cat <<TEMPLATE
 <strong>$NOTIFICATIONTYPE</strong> $HOSTDISPLAYNAME - $SERVICEDISPLAYNAME is $SERVICESTATE
 
 Address: $HOSTADDRESS
 Date/Time: $LONGDATETIME
 
-<pre>$SERVICEOUTPUT</pre>
+<pre>$SERVICEOUTPUT_ESCAPED</pre>
 TEMPLATE
 )
 


### PR DESCRIPTION
HTML escape the check outputs before sending to telegram because it will silently fail sometimes.

I just used this sed(bazooka) found on stackoverflow: https://stackoverflow.com/questions/12873682/short-way-to-escape-html-in-bash